### PR TITLE
Return Joi validators errors on exception

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -177,14 +177,15 @@ export default async function({ path, log }: N9Micro.Options, app: Express) {
 		const status = err.status || 500
 		const code = err.message || 'unspecified-error'
 		const context = err.context || {}
-		if (status >= 500) {
+		if (status >= 500 || status === 400) {
 			log.error(err)
 		}
 		res.status(status)
 		res.json({
 			code,
 			status,
-			context
+			context,
+			error: status === 400 ? err : undefined
 		})
 	})
 }

--- a/test/micro-validate.ts
+++ b/test/micro-validate.ts
@@ -15,6 +15,8 @@ const closeServer = (server) => {
 const MICRO_VALIDATE = join(__dirname, 'fixtures/micro-validate/')
 
 test('Check allowUnkown', async (t) => {
+	const env = process.env.NODE_ENV
+	process.env.NODE_ENV = 'production'
 	stdMock.use()
 	const { app, server } = await n9Micro({
 		path: MICRO_VALIDATE,
@@ -63,4 +65,5 @@ test('Check allowUnkown', async (t) => {
 	const output = stdMock.flush()
 	// Close server
 	await closeServer(server)
+	process.env.NODE_ENV = env
 })


### PR DESCRIPTION
print the logs and return the express validation errors when the route's Joi validator fail